### PR TITLE
Configurable autofocus

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ export default App;
 |**profileAvatar**|PropTypes.string|NO| |The profile image that will be set on the responses|
 |**showCloseButton**|PropTypes.bool|NO|false|Show or hide the close button in full screen mode|
 |**fullScreenMode**|PropTypes.bool|NO|false|Allow the use of full screen in full desktop mode|
+|**autofocus**|PropTypes.bool|NO|true|Autofocus or not the user input|
 
 #### Styles
 

--- a/src/components/Widget/components/Conversation/components/Sender/index.js
+++ b/src/components/Widget/components/Conversation/components/Sender/index.js
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import send from 'assets/send_button.svg';
 import './style.scss';
 
-const Sender = ({ sendMessage, placeholder, disabledInput }) =>
+const Sender = ({ sendMessage, placeholder, disabledInput, autofocus }) =>
   <form className="sender" onSubmit={sendMessage}>
-    <input type="text" className="new-message" name="message" placeholder={placeholder} disabled={disabledInput} autoFocus autoComplete="off" />
+    <input type="text" className="new-message" name="message" placeholder={placeholder} disabled={disabledInput} autoFocus={autofocus} autoComplete="off" />
     <button type="submit" className="send">
       <img src={send} className="send-icon" alt="send" />
     </button>
@@ -15,7 +15,8 @@ const Sender = ({ sendMessage, placeholder, disabledInput }) =>
 Sender.propTypes = {
   sendMessage: PropTypes.func,
   placeholder: PropTypes.string,
-  disabledInput: PropTypes.bool
+  disabledInput: PropTypes.bool,
+  autofocus: PropTypes.bool,
 };
 
 export default Sender;

--- a/src/components/Widget/components/Conversation/index.js
+++ b/src/components/Widget/components/Conversation/index.js
@@ -21,6 +21,7 @@ const Conversation = props =>
       sendMessage={props.sendMessage}
       placeholder={props.senderPlaceHolder}
       disabledInput={props.disabledInput}
+      autofocus={props.autofocus}
     />
   </div>;
 
@@ -32,7 +33,8 @@ Conversation.propTypes = {
   profileAvatar: PropTypes.string,
   toggleChat: PropTypes.func,
   showCloseButton: PropTypes.bool,
-  disabledInput: PropTypes.bool
+  disabledInput: PropTypes.bool,
+  autofocus: PropTypes.bool
 };
 
 export default Conversation;

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -37,6 +37,7 @@ class Widget extends Component {
         profileAvatar={this.props.profileAvatar}
         showCloseButton={this.props.showCloseButton}
         fullScreenMode={this.props.fullScreenMode}
+        autofocus={this.props.autofocus}
       />
     );
   }
@@ -49,7 +50,8 @@ Widget.propTypes = {
   senderPlaceHolder: PropTypes.string,
   profileAvatar: PropTypes.string,
   showCloseButton: PropTypes.bool,
-  fullScreenMode: PropTypes.bool
+  fullScreenMode: PropTypes.bool,
+  autofocus: PropTypes.bool
 };
 
 export default connect()(Widget);

--- a/src/components/Widget/layout.js
+++ b/src/components/Widget/layout.js
@@ -20,6 +20,7 @@ const WidgetLayout = props =>
         showChat={props.showChat}
         showCloseButton={props.showCloseButton}
         disabledInput={props.disabledInput}
+        autofocus={props.autofocus}
       />
     }
     {
@@ -40,7 +41,8 @@ WidgetLayout.propTypes = {
   profileAvatar: PropTypes.string,
   showCloseButton: PropTypes.bool,
   disabledInput: PropTypes.bool,
-  fullScreenMode: PropTypes.bool
+  fullScreenMode: PropTypes.bool,
+  autofocus: PropTypes.bool,
 };
 
 export default connect(store => ({

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ const ConnectedWidget = props =>
       profileAvatar={props.profileAvatar}
       showCloseButton={props.showCloseButton}
       fullScreenMode={props.fullScreenMode}
+      autofocus={props.autofocus}
     />
   </Provider>;
 
@@ -25,7 +26,8 @@ ConnectedWidget.propTypes = {
   senderPlaceHolder: PropTypes.string,
   profileAvatar: PropTypes.string,
   showCloseButton: PropTypes.bool,
-  fullScreenMode: PropTypes.bool
+  fullScreenMode: PropTypes.bool,
+  autofocus: PropTypes.bool
 };
 
 ConnectedWidget.defaultProps = {
@@ -33,7 +35,8 @@ ConnectedWidget.defaultProps = {
   subtitle: 'This is your chat subtitle',
   senderPlaceHolder: 'Type a message...',
   showCloseButton: true,
-  fullScreenMode: false
+  fullScreenMode: false,
+  autofocus: true
 };
 
 export default ConnectedWidget;


### PR DESCRIPTION
My app is made to be used on mobile phone. With the default behaviour, when the chat is toggle, the input is autofocus so the keyboard open and I can't see the first message.

I added an `autofocus` props, in my case I will set it to `false` so the user will have to select the input before typing, but he can see the first message before doing so.

Comparison: 

- `autofocus` is `true`:
![true](https://user-images.githubusercontent.com/6841201/36268859-ee7e5ccc-1277-11e8-9afe-89a07c757ed4.gif)

- `autofocus` is `false`:
![false](https://user-images.githubusercontent.com/6841201/36268864-f14a4b00-1277-11e8-8782-4f3da80e6abe.gif)
