### PR TITLE
change marked to  markdown-it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -195,7 +195,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -3357,8 +3356,7 @@
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-      "dev": true
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "envinfo": {
       "version": "4.4.2",
@@ -6589,6 +6587,14 @@
         "type-check": "0.3.2"
       }
     },
+    "linkify-it": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
+      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+      "requires": {
+        "uc.micro": "1.0.5"
+      }
+    },
     "listr": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
@@ -7018,6 +7024,33 @@
         "object-visit": "1.0.1"
       }
     },
+    "markdown-it": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.1.tgz",
+      "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
+      "requires": {
+        "argparse": "1.0.10",
+        "entities": "1.1.1",
+        "linkify-it": "2.0.3",
+        "mdurl": "1.0.1",
+        "uc.micro": "1.0.5"
+      }
+    },
+    "markdown-it-link-attributes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-link-attributes/-/markdown-it-link-attributes-2.1.0.tgz",
+      "integrity": "sha1-MqdMlPfFzf0Iho0r7inG+nCggyQ="
+    },
+    "markdown-it-sanitizer": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-sanitizer/-/markdown-it-sanitizer-0.4.3.tgz",
+      "integrity": "sha1-K6NOn+FuY3LOcZL7ULN9nfv/AQI="
+    },
+    "markdown-it-sup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-sup/-/markdown-it-sup-1.0.0.tgz",
+      "integrity": "sha1-y5yf+RpSVawI8/09YyhuFd8KH8M="
+    },
     "marked": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
@@ -7038,6 +7071,11 @@
         "hash-base": "3.0.4",
         "inherits": "2.0.3"
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "mem": {
       "version": "1.1.0",
@@ -12176,8 +12214,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.14.1",
@@ -13103,6 +13140,11 @@
       "version": "0.7.17",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+    },
+    "uc.micro": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
+      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
   ],
   "dependencies": {
     "immutable": "^3.8.1",
+    "markdown-it": "^8.4.1",
+    "markdown-it-link-attributes": "^2.1.0",
+    "markdown-it-sanitizer": "^0.4.3",
+    "markdown-it-sup": "^1.0.0",
     "marked": "^0.3.19",
     "prop-types": "^15.5.10",
     "react-immutable-proptypes": "^2.1.0",

--- a/src/components/Widget/components/Conversation/components/Messages/components/Message/index.js
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Message/index.js
@@ -1,12 +1,19 @@
 import React, { PureComponent } from 'react';
-import marked from 'marked';
+import markdownIt from 'markdown-it';
+import markdownItSup from 'markdown-it-sup';
+import markdownItSanitizer from 'markdown-it-sanitizer';
+import markdownItLinkAttributes from 'markdown-it-link-attributes';
 import { PROP_TYPES } from 'constants';
 
 import './styles.scss';
 
 class Message extends PureComponent {
   render() {
-    const sanitizedHTML = marked.parse(this.props.message.get('text'), { sanitize: true });
+    const sanitizedHTML = markdownIt()
+    .use(markdownItSup)
+    .use(markdownItSanitizer)
+    .use(markdownItLinkAttributes, { attrs: { target: '_blank', rel: 'noopener' } })
+    .render(this.props.message.get('text'));
 
     return (
       <div className={this.props.message.get('sender')}>


### PR DESCRIPTION
## Summary
- i change marked library to markdown-it to handle <sub> and  <sup> after sanitize.
- i add markdown-it-sanitizer plugin.
- i add markdown-it-link-attributes plugin to handle link's attr settings.
