### PR TITLE
Allow the addUserMessage to be disabled

### DIFF
--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -21,7 +21,9 @@ class Widget extends Component {
     event.preventDefault();
     const userInput = event.target.message.value;
     if (userInput) {
-      this.props.dispatch(addUserMessage(userInput));
+        if(this.props.addUserMessage) {
+            this.props.dispatch(addUserMessage(userInput));
+        }
       this.props.handleNewUserMessage(userInput);
     }
     event.target.message.value = '';
@@ -53,6 +55,7 @@ Widget.propTypes = {
   titleAvatar: PropTypes.string,
   subtitle: PropTypes.string,
   handleNewUserMessage: PropTypes.func.isRequired,
+  addUserMessage: PropTypes.bool,
   senderPlaceHolder: PropTypes.string,
   profileAvatar: PropTypes.string,
   showCloseButton: PropTypes.bool,

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const ConnectedWidget = props =>
       titleAvatar={props.titleAvatar}
       subtitle={props.subtitle}
       handleNewUserMessage={props.handleNewUserMessage}
+      addUserMessage={props.addUserMessage}
       senderPlaceHolder={props.senderPlaceHolder}
       profileAvatar={props.profileAvatar}
       showCloseButton={props.showCloseButton}
@@ -27,6 +28,7 @@ ConnectedWidget.propTypes = {
   titleAvatar: PropTypes.string,
   subtitle: PropTypes.string,
   handleNewUserMessage: PropTypes.func.isRequired,
+  addUserMessage: PropTypes.bool,
   senderPlaceHolder: PropTypes.string,
   profileAvatar: PropTypes.string,
   showCloseButton: PropTypes.bool,
@@ -43,7 +45,8 @@ ConnectedWidget.defaultProps = {
   showCloseButton: true,
   fullScreenMode: false,
   badge: 0,
-  autofocus: true
+  autofocus: true,
+  addUserMessage: true
 };
 
 export default ConnectedWidget;


### PR DESCRIPTION
Allow the addUserMessage to be disabled, this will resolve issue 45 and allows the developer to use any of the "Messages" functions available (in particular renderCustomComponent) in the handleNewUserMessage. This supports the use case where the message first needs to be submitted to a server or validated prior being added to the store/displayed to the user.

Introduces no BC breaks - existing workflow is default