### PR TITLE
Whitespaces as input (Bug) 

### DIFF
--- a/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
+++ b/src/components/Widget/components/Conversation/components/Messages/components/Message/styles.scss
@@ -4,6 +4,7 @@
 .rcw-message {
   margin: 10px;
   display: flex;
+  word-wrap: break-word;
 }
 
 .rcw-client {

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -20,7 +20,7 @@ class Widget extends Component {
   handleMessageSubmit = (event) => {
     event.preventDefault();
     const userInput = event.target.message.value;
-    if (userInput) {
+    if (userInput.trim()) {
       this.props.dispatch(addUserMessage(userInput));
       this.props.handleNewUserMessage(userInput);
     }


### PR DESCRIPTION
## Summary

- Fixed `handleMessageSubmit` method to avoid whitespaces as `userInput`
- Added word wrapping to avoid long words from breaking the chat layout