### PR TITLE
Refactored Sender component to use createRef()

### DIFF
--- a/src/components/Widget/components/Conversation/components/Sender/index.js
+++ b/src/components/Widget/components/Conversation/components/Sender/index.js
@@ -1,17 +1,30 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import send from '@assets/send_button.svg';
 
 import './style.scss';
 
-const Sender = ({ sendMessage, placeholder, disabledInput, autofocus }) =>
-  <form className="rcw-sender" onSubmit={sendMessage}>
-    <input type="text" className="rcw-new-message" name="message" placeholder={placeholder} disabled={disabledInput} autoFocus={autofocus} autoComplete="off" />
-    <button type="submit" className="rcw-send">
-      <img src={send} className="rcw-send-icon" alt="send" />
-    </button>
-  </form>;
+class Sender extends Component{
+  input = React.createRef();
+
+  componentDidUpdate() {
+    this.input.current.focus();
+  }
+
+  render() {
+    const { sendMessage, placeholder, disabledInput, autofocus } = this.props;
+    return (
+      <form className="rcw-sender" onSubmit={sendMessage}>
+        <input type="text" className="rcw-new-message" name="message" placeholder={placeholder} disabled={disabledInput} autoFocus={autofocus} autoComplete="off" ref={this.input}/>
+        <button type="submit" className="rcw-send">
+          <img src={send} className="rcw-send-icon" alt="send" />
+        </button>
+      </form>
+    );
+  }
+
+}
 
 Sender.propTypes = {
   sendMessage: PropTypes.func,


### PR DESCRIPTION
## Summary

- Refactored Sender component so that it can be focused automatically when disabled and then enabled back. Autofocus only works when the component is rendered for the first time

## Screenshot

![sender](https://user-images.githubusercontent.com/36488701/52011301-55953380-24b6-11e9-9d38-68f7d3e3148f.gif)

## Issue
https://github.com/Wolox/react-chat-widget/issues/92