### PR TITLE
a11y: added ARIA live, chatId and labels for launcher button

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ export default App;
 |   |type|required|default value|description|
 |---|--- |---     |---          |---        |
 |**handleNewUserMessage**|PropTypes.func|YES| |Function to handle the user input, will receive the full text message when submitted|
+|**id**|PropTypes.string|NO|'rcw-chat-container'|Id of the widget, overridable if you have more than one in DOM|
 |**title**|PropTypes.string|NO|'Welcome'|Title of the widget|
 |**subtitle**|PropTypes.string|NO|'This is your chat subtitle'|Subtitle of the widget|
 |**senderPlaceHolder**|PropTypes.string|NO|'Type a message...'|The placeholder of the message input|
@@ -163,6 +164,8 @@ export default App;
 |**autofocus**|PropTypes.bool|NO|true|Autofocus or not the user input|
 |**launcher**|PropTypes.func|NO||Custom Launcher component to use instead of the default|
 |**handleQuickButtonClicked**|PropTypes.func|NO||Function to handle the user clicking a quick button, will receive the 'value' when clicked.|
+|**launcherOpenLabel**|PropTypes.string|NO|'Open chat'|Text used by screen readers for the button to open chat|
+|**launcherCloseLabel**|PropTypes.string|NO|'Close chat'|Text used by screen readers for the button to close chat|
 
 #### Styles
 

--- a/src/components/Widget/components/Conversation/index.js
+++ b/src/components/Widget/components/Conversation/index.js
@@ -8,7 +8,9 @@ import QuickButtons from './components/QuickButtons';
 import './style.scss';
 
 const Conversation = props =>
-  <div className="rcw-conversation-container">
+  <div className="rcw-conversation-container"
+       aria-live="polite"
+       id={props.chatId}>
     <Header
       title={props.title}
       subtitle={props.subtitle}
@@ -29,6 +31,7 @@ const Conversation = props =>
   </div>;
 
 Conversation.propTypes = {
+  chatId: PropTypes.string,
   title: PropTypes.string,
   titleAvatar: PropTypes.string,
   subtitle: PropTypes.string,

--- a/src/components/Widget/components/Launcher/index.js
+++ b/src/components/Widget/components/Launcher/index.js
@@ -7,19 +7,43 @@ import close from '@assets/clear-button.svg';
 import Badge from './components/Badge';
 import './style.scss';
 
-const Launcher = ({ toggle, chatOpened, badge }) =>
-  <button type="button" className={chatOpened ? 'rcw-launcher rcw-hide-sm' : 'rcw-launcher'} onClick={toggle}>
+const Launcher = ({
+  chatId,
+  toggle,
+  chatOpened,
+  badge,
+  launcherOpenLabel,
+  launcherCloseLabel,
+}) => (
+  <button
+    type="button"
+    className={chatOpened ? 'rcw-launcher rcw-hide-sm' : 'rcw-launcher'}
+    onClick={toggle}
+    aria-controls={chatId}>
     <Badge badge={badge} />
-    {chatOpened ?
-      <img src={close} className="rcw-close-launcher" alt="" /> :
-      <img src={openLauncher} className="rcw-open-launcher" alt="" />
-    }
-  </button>;
+    {chatOpened ? (
+      <img
+        src={close}
+        className="rcw-close-launcher"
+        alt={launcherCloseLabel}
+      />
+    ) : (
+      <img
+        src={openLauncher}
+        className="rcw-open-launcher"
+        alt={launcherOpenLabel}
+      />
+    )}
+  </button>
+);
 
 Launcher.propTypes = {
+  chatId: PropTypes.string,
   toggle: PropTypes.func,
   chatOpened: PropTypes.bool,
-  badge: PropTypes.number
+  badge: PropTypes.number,
+  launcherOpenLabel: PropTypes.string,
+  launcherCloseLabel: PropTypes.string,
 };
 
 export default connect(store => ({

--- a/src/components/Widget/index.js
+++ b/src/components/Widget/index.js
@@ -17,7 +17,7 @@ class Widget extends Component {
     this.props.dispatch(toggleChat());
   }
 
-  handleMessageSubmit = (event) => {
+  handleMessageSubmit = event => {
     event.preventDefault();
     const userInput = event.target.message.value;
     if (userInput.trim()) {
@@ -30,7 +30,7 @@ class Widget extends Component {
   handleQuickButtonClicked = (event, value) => {
     event.preventDefault();
 
-    if(this.props.handleQuickButtonClicked) {
+    if (this.props.handleQuickButtonClicked) {
       this.props.handleQuickButtonClicked(value);
     }
   }
@@ -41,6 +41,7 @@ class Widget extends Component {
         onToggleConversation={this.toggleConversation}
         onSendMessage={this.handleMessageSubmit}
         onQuickButtonClicked={this.handleQuickButtonClicked}
+        chatId={this.props.chatId}
         title={this.props.title}
         titleAvatar={this.props.titleAvatar}
         subtitle={this.props.subtitle}
@@ -51,12 +52,15 @@ class Widget extends Component {
         badge={this.props.badge}
         autofocus={this.props.autofocus}
         customLauncher={this.props.customLauncher}
+        launcherOpenLabel={this.props.launcherOpenLabel}
+        launcherCloseLabel={this.props.launcherCloseLabel}
       />
     );
   }
 }
 
 Widget.propTypes = {
+  chatId: PropTypes.string,
   title: PropTypes.string,
   titleAvatar: PropTypes.string,
   subtitle: PropTypes.string,
@@ -68,7 +72,9 @@ Widget.propTypes = {
   fullScreenMode: PropTypes.bool,
   badge: PropTypes.number,
   autofocus: PropTypes.bool,
-  customLauncher: PropTypes.func
+  customLauncher: PropTypes.func,
+  launcherOpenLabel: PropTypes.string,
+  launcherCloseLabel: PropTypes.string,
 };
 
 export default connect()(Widget);

--- a/src/components/Widget/layout.js
+++ b/src/components/Widget/layout.js
@@ -14,6 +14,7 @@ const WidgetLayout = props => (
   >
     {props.showChat &&
       <Conversation
+        chatId={props.chatId}
         title={props.title}
         subtitle={props.subtitle}
         sendMessage={props.onSendMessage}
@@ -32,14 +33,18 @@ const WidgetLayout = props => (
       props.customLauncher(props.onToggleConversation) :
       !props.fullScreenMode &&
       <Launcher
+        chatId={props.chatId}
         toggle={props.onToggleConversation}
         badge={props.badge}
+        launcherOpenLabel={props.launcherOpenLabel}
+        launcherCloseLabel={props.launcherCloseLabel}
       />
     }
   </div>
 );
 
 WidgetLayout.propTypes = {
+  chatId: PropTypes.string,
   title: PropTypes.string,
   titleAvatar: PropTypes.string,
   subtitle: PropTypes.string,
@@ -54,7 +59,9 @@ WidgetLayout.propTypes = {
   fullScreenMode: PropTypes.bool,
   badge: PropTypes.number,
   autofocus: PropTypes.bool,
-  customLauncher: PropTypes.func
+  customLauncher: PropTypes.func,
+  launcherOpenLabel: PropTypes.string,
+  launcherCloseLabel: PropTypes.string,
 };
 
 export default connect(store => ({

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import store from '../src/store/store';
 const ConnectedWidget = props =>
   <Provider store={store}>
     <Widget
+      chatId={props.chatId}
       title={props.title}
       titleAvatar={props.titleAvatar}
       subtitle={props.subtitle}
@@ -20,10 +21,13 @@ const ConnectedWidget = props =>
       badge={props.badge}
       autofocus={props.autofocus}
       customLauncher={props.launcher}
+      launcherOpenLabel={props.launcherOpenLabel}
+      launcherCloseLabel={props.launcherCloseLabel}
     />
   </Provider>;
 
 ConnectedWidget.propTypes = {
+  chatId: PropTypes.string,
   title: PropTypes.string,
   titleAvatar: PropTypes.string,
   subtitle: PropTypes.string,
@@ -35,17 +39,22 @@ ConnectedWidget.propTypes = {
   fullScreenMode: PropTypes.bool,
   badge: PropTypes.number,
   autofocus: PropTypes.bool,
-  launcher: PropTypes.func
+  launcher: PropTypes.func,
+  launcherOpenLabel: PropTypes.string,
+  launcherCloseLabel: PropTypes.string,
 };
 
 ConnectedWidget.defaultProps = {
+  chatId: 'rcw-chat-container',
   title: 'Welcome',
   subtitle: 'This is your chat subtitle',
   senderPlaceHolder: 'Type a message...',
   showCloseButton: true,
   fullScreenMode: false,
   badge: 0,
-  autofocus: true
+  autofocus: true,
+  launcherOpenLabel: 'Open chat',
+  launcherCloseLabel: 'Close chat',
 };
 
 export default ConnectedWidget;


### PR DESCRIPTION
Fixes https://github.com/Wolox/react-chat-widget/issues/119.

I'm introducing two new props for the Launcher: `launcherOpenLabel` and `launcherCloseLabel`.
These are used in the `alt` attribute of the images in the button, so screen readers use it to give to users a feedback on what they would do with this button.
I also added the `chatId` prop to customize the `id` attribute I added in order to handle ARIA live region with `aria-controls` and `aria-live`.